### PR TITLE
Hide minimized windows in screenshot UI

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,10 +1,16 @@
+const Config = imports.misc.config;
+const [major] = Config.PACKAGE_VERSION.split('.');
+const shellVersion = Number.parseInt(major);
+
 const isOverviewWindow = imports.ui.workspace.Workspace.prototype._isOverviewWindow;
 const { Workspace } = imports.ui.workspace;
 const { altTab } = imports.ui;
 const { getWindows } = altTab;
-const capture = imports.ui.screenshot.UIWindowSelector.prototype.capture;
-const { UIWindowSelector, UIWindowSelectorWindow } = imports.ui.screenshot;
-const Main = imports.ui.main;
+if(shellVersion >= 42) {
+  var capture = imports.ui.screenshot.UIWindowSelector.prototype.capture;
+  var { UIWindowSelector, UIWindowSelectorWindow } = imports.ui.screenshot;
+  var Main = imports.ui.main;
+}
 
 function init() {
 }
@@ -21,46 +27,50 @@ function enable() {
     const windows = getWindows(workspace);
     return windows.filter((w, i, a) => !w.minimized);
   };
-  // Patched version of original function from:
-  // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/screenshot.js
-  UIWindowSelector.prototype.capture = function() {
-    for (const actor of global.get_window_actors()) {
-      let window = actor.metaWindow;
-      let workspaceManager = global.workspace_manager;
-      let activeWorkspace = workspaceManager.get_active_workspace();
-      if (window.is_override_redirect() ||
-          !window.located_on_workspace(activeWorkspace) ||
-          window.get_monitor() !== this._monitorIndex ||
-          window.minimized)
-          continue;
+  if(shellVersion >= 42) {
+    // Patched version of original function from:
+    // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/screenshot.js
+    UIWindowSelector.prototype.capture = function() {
+      for (const actor of global.get_window_actors()) {
+        let window = actor.metaWindow;
+        let workspaceManager = global.workspace_manager;
+        let activeWorkspace = workspaceManager.get_active_workspace();
+        if (window.is_override_redirect() ||
+            !window.located_on_workspace(activeWorkspace) ||
+            window.get_monitor() !== this._monitorIndex ||
+            window.minimized)
+            continue;
 
-      const widget = new UIWindowSelectorWindow(
-          actor,
-          {
-              style_class: 'screenshot-ui-window-selector-window',
-              reactive: true,
-              can_focus: true,
-              toggle_mode: true,
-          }
-      );
+        const widget = new UIWindowSelectorWindow(
+            actor,
+            {
+                style_class: 'screenshot-ui-window-selector-window',
+                reactive: true,
+                can_focus: true,
+                toggle_mode: true,
+            }
+        );
 
-      widget.connect('key-focus-in', win => {
-          Main.screenshotUI.grab_key_focus();
-          win.checked = true;
-      });
+        widget.connect('key-focus-in', win => {
+            Main.screenshotUI.grab_key_focus();
+            win.checked = true;
+        });
 
-      if (window.has_focus()) {
-          widget.checked = true;
-          widget.toggle_mode = false;
+        if (window.has_focus()) {
+            widget.checked = true;
+            widget.toggle_mode = false;
+        }
+
+        this._layoutManager.addWindow(widget);
       }
-
-      this._layoutManager.addWindow(widget);
-    }
-  };
+    };
+  }
 }
 
 function disable() {
   Workspace.prototype._isOverviewWindow = isOverviewWindow;
   altTab.getWindows = getWindows;
-  UIWindowSelector.prototype.capture = capture;
+  if(shellVersion >= 42) {
+    UIWindowSelector.prototype.capture = capture;
+  }
 }

--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,9 @@ const isOverviewWindow = imports.ui.workspace.Workspace.prototype._isOverviewWin
 const { Workspace } = imports.ui.workspace;
 const { altTab } = imports.ui;
 const { getWindows } = altTab;
+const capture = imports.ui.screenshot.UIWindowSelector.prototype.capture;
+const { UIWindowSelector, UIWindowSelectorWindow } = imports.ui.screenshot;
+const Main = imports.ui.main;
 
 function init() {
 }
@@ -18,9 +21,46 @@ function enable() {
     const windows = getWindows(workspace);
     return windows.filter((w, i, a) => !w.minimized);
   };
+  // Patched version of original function from:
+  // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/screenshot.js
+  UIWindowSelector.prototype.capture = function() {
+    for (const actor of global.get_window_actors()) {
+      let window = actor.metaWindow;
+      let workspaceManager = global.workspace_manager;
+      let activeWorkspace = workspaceManager.get_active_workspace();
+      if (window.is_override_redirect() ||
+          !window.located_on_workspace(activeWorkspace) ||
+          window.get_monitor() !== this._monitorIndex ||
+          window.minimized)
+          continue;
+
+      const widget = new UIWindowSelectorWindow(
+          actor,
+          {
+              style_class: 'screenshot-ui-window-selector-window',
+              reactive: true,
+              can_focus: true,
+              toggle_mode: true,
+          }
+      );
+
+      widget.connect('key-focus-in', win => {
+          Main.screenshotUI.grab_key_focus();
+          win.checked = true;
+      });
+
+      if (window.has_focus()) {
+          widget.checked = true;
+          widget.toggle_mode = false;
+      }
+
+      this._layoutManager.addWindow(widget);
+    }
+  };
 }
 
 function disable() {
   Workspace.prototype._isOverviewWindow = isOverviewWindow;
   altTab.getWindows = getWindows;
+  UIWindowSelector.prototype.capture = capture;
 }


### PR DESCRIPTION
Hi,
When using this extension, the new screenshot UI introduced in GNOME 42 shows the minimized windows as either a completely dark box or as a dark box with some visible fragments.

This pull request solves this issue and completes the functionality of this extension by also hiding the minimized windows in the screenshot UI. I have tested the changes on Arch Linux with GNOME 42.1 and Ubuntu 20.04.4 LTS with GNOME 3.36.8.

Best regards,
Daniel