### PR TITLE
Update metadata.json to support GNOME 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "hide-minimized@danigm.net",
     "name": "Hide minimized",
     "url": "https://github.com/danigm/hide-minimized",
-    "shell-version": ["3.30", "3.32", "3.34", "3.36", "3.38", "40", "41", "42"]
+    "shell-version": ["3.30", "3.32", "3.34", "3.36", "3.38", "40", "41", "42", "43"]
 }


### PR DESCRIPTION
This adds GNOME 43 support; tested on Fedora 37, everything works as expected.