### PR TITLE
Update metadata.json for Gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "hide-minimized@danigm.net",
     "name": "Hide minimized",
     "url": "https://github.com/danigm/hide-minimized",
-    "shell-version": ["3.30", "3.32", "3.34", "3.36", "3.38", "40", "41", "42", "43"]
+    "shell-version": ["3.30", "3.32", "3.34", "3.36", "3.38", "40", "41", "42", "43", "44"]
 }


### PR DESCRIPTION
Gnome 44 was released on March 22, 2023. This PR add 44 to the manifest. 