### PR TITLE
Update metadata.json to support GNOME 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "hide-minimized@danigm.net",
     "name": "Hide minimized",
     "url": "https://github.com/danigm/hide-minimized",
-    "shell-version": ["45"]
+    "shell-version": ["45", "46"]
 }


### PR DESCRIPTION
The extension seems to work without problems on GNOME 46.