### PR TITLE
Gnome 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "hide-minimized@danigm.net",
     "name": "Hide minimized",
     "url": "https://github.com/danigm/hide-minimized",
-    "shell-version": ["45", "46"]
+    "shell-version": ["45", "46", "47"]
 }


### PR DESCRIPTION
Added Gnome shell version 47 to metadata.json as that is, again, the only necessary change for the shell update