### PR TITLE
Update metadata.json to add support to gnome 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "hide-minimized@danigm.net",
     "name": "Hide minimized",
     "url": "https://github.com/danigm/hide-minimized",
-    "shell-version": ["45", "46", "47"]
+    "shell-version": ["45", "46", "47", "48"]
 }


### PR DESCRIPTION
The extension seems to work properly on GNOME 48