### PR TITLE
Update metadata.json to add support to Gnome 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
     "uuid": "hide-minimized@danigm.net",
     "name": "Hide minimized",
     "url": "https://github.com/danigm/hide-minimized",
-    "shell-version": ["45", "46", "47", "48"]
+    "shell-version": ["45", "46", "47", "48", "49"]
 }


### PR DESCRIPTION
Everything appears to work fine with no other changes.